### PR TITLE
Fix typo: Pluto can run now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ build/pluto.iso: build/kernel.bin
 	echo '  multiboot /boot/kernel.bin'    >> build/iso/boot/grub/grub.cfg
 	echo '  boot'                            >> build/iso/boot/grub/grub.cfg
 	echo '}'                                 >> build/iso/boot/grub/grub.cfg
-	grub-mkrescue --output=build/pluto.iso
+	grub-mkrescue --output=build/pluto.iso build/iso
 
 install: build/kernel.bin
 	sudo cp $< /boot/kernel.bin


### PR DESCRIPTION
Fixed a typo in the Makefile:

grub-mkrescue didn't copy the kernel so GRUB entered rescue shell. Added directory what to add so it's fixed now.